### PR TITLE
Allow genrule dependencies in cc_ build rules.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
@@ -116,7 +116,7 @@ public class BazelCppRuleClasses {
 
   static final String[] DEPS_ALLOWED_RULES =
       new String[] {
-        "cc_inc_library", "cc_library", "objc_library", "cc_proto_library", "cc_import",
+        "cc_inc_library", "cc_library", "objc_library", "cc_proto_library", "cc_import", "genrule",
       };
 
   /**


### PR DESCRIPTION
This is going to be contentious. On one hand, power and expressiveness, and on the other, non-hermetic builds.

I have some rules that need to depend on linker scripts (which are allowed dependencies), but those scripts are generated by a genrule that includes some symbols or not depending on config_settings interpreted through select expressions.

Will this ever be allowed? If not, can we get some kind of provider for a Skylark rule to apply as some kind of "yes, I accept the risks and responsibilities of being a cc_ rule dependency."?